### PR TITLE
Bot API 4.4 ChatPermissions compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ bot.
 """
 import os
 import logging
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, ChatPermissions
 from telegram.ext import Filters, Updater, MessageHandler, CommandHandler, CallbackQueryHandler
 from random import shuffle
 
@@ -49,13 +49,16 @@ def hodor(update, context):
     try:
         for new_member in update.message.new_chat_members:
             callback_id = str(new_member.id)
-            context.bot.restrict_chat_member(
-                int(os.environ['CHAT_ID']),
-                new_member.id,
+            permissions = ChatPermissions(
                 can_send_messages=False,
                 can_send_media_messages=False,
                 can_send_other_messages=False,
                 can_add_web_page_previews=False
+                )
+            context.bot.restrict_chat_member(
+                int(CHAT_ID),
+                new_member.id,
+                permissions,
             )
 
             keyboard_items = [
@@ -112,13 +115,16 @@ def button(update, context):
                 chat_id=update.callback_query.message.chat_id,
                 message_id=update.callback_query.message.message_id
             )
-            context.bot.restrict_chat_member(
-                int(os.environ['CHAT_ID']),
-                person_who_pushed_the_button,
+            permissions = ChatPermissions(
                 can_send_messages=True,
                 can_send_media_messages=True,
                 can_send_other_messages=True,
-                can_add_web_page_previews=True
+                can_add_web_page_previews=True,
+                )
+            context.bot.restrict_chat_member(
+                int(CHAT_ID),
+                person_who_pushed_the_button,
+                permissions,
             )
         else:
             query.edit_message_text(text="🚨 A robot suspect was just put on hold! 🚨")


### PR DESCRIPTION
This ist out of the docstring of restrict_chat_member:

Since Bot API 4.4, :attr:`restrict_chat_member` takes the new user permissions in a
single argument of type :class:`telegram.ChatPermissions`. The old way of passing
parameters will not keep working forever.